### PR TITLE
feat!: remove TYDOM_PASSWORD, now fetched automatically

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -24,5 +24,5 @@ docker build -t tydom2mqtt .
 
 ### Run the Docker image
 ```bash
-docker run -it --rm -e TYDOM_MAC="001A25123456" -e TYDOM_PASSWORD="secret" tydom2mqtt
+docker run -it --rm -e TYDOM_MAC="001A25123456" -e TYDOM_IP="192.168.1.33" -v "$(pwd)/tydom-data:/data" tydom2mqtt
 ```

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -21,7 +21,6 @@ TYDOM_ALARM_NIGHT_ZONE = "TYDOM_ALARM_NIGHT_ZONE"
 TYDOM_ALARM_PIN = "TYDOM_ALARM_PIN"
 TYDOM_IP = "TYDOM_IP"
 TYDOM_MAC = "TYDOM_MAC"
-TYDOM_PASSWORD = "TYDOM_PASSWORD"
 TYDOM_POLLING_INTERVAL = "TYDOM_POLLING_INTERVAL"
 TYDOM_STATE_DIR = "TYDOM_STATE_DIR"
 TYDOM_PAIRING_TIMEOUT = "TYDOM_PAIRING_TIMEOUT"
@@ -67,15 +66,12 @@ class Configuration:
         self.tydom_alarm_pin = os.getenv(TYDOM_ALARM_PIN, None)
         self.tydom_ip = os.getenv(TYDOM_IP, "mediation.tydom.com")
         self.tydom_mac = os.getenv(TYDOM_MAC, None)
-        self.tydom_password = os.getenv(TYDOM_PASSWORD, None)
+        # Never configured directly: local mode pairs with the hub, remote
+        # mode gets it from the Delta Dore cloud.
+        self.tydom_password = None
         self.tydom_polling_interval = os.getenv(TYDOM_POLLING_INTERVAL, 300)
         self.tydom_state_dir = os.getenv(TYDOM_STATE_DIR, "/data")
         self.tydom_pairing_timeout = os.getenv(TYDOM_PAIRING_TIMEOUT, 180)
-        # Remember whether the user supplied a password, so that neither the
-        # cloud lookup nor the stored value silently overrides their choice.
-        self.tydom_password_is_explicit = (
-            self.tydom_password is not None and self.tydom_password != ""
-        )
         self.password_store = PasswordStore(self.tydom_state_dir)
         self.deltadore_login = os.getenv(DELTADORE_LOGIN, None)
         self.deltadore_password = os.getenv(DELTADORE_PASSWORD, None)
@@ -106,14 +102,10 @@ class Configuration:
     def resolve_local_password(self):
         """Reuse the local password kept from a previous pairing, if any.
 
-        An explicitly configured password always wins, so this never
-        overrides what the user asked for. When nothing is available the
-        password stays empty and the client pairs with the hub at startup.
+        When nothing is stored the password stays empty and the client pairs
+        with the hub at startup, which is the only way to obtain it.
         """
         if not self.is_local_mode():
-            return
-
-        if self.tydom_password is not None and self.tydom_password != "":
             return
 
         stored = self.password_store.read()
@@ -139,9 +131,6 @@ class Configuration:
 
                     if TYDOM_IP in data and data[TYDOM_IP] != "":
                         self.tydom_ip = data[TYDOM_IP]
-
-                    if TYDOM_PASSWORD in data and data[TYDOM_PASSWORD] != "":
-                        self.tydom_password = data[TYDOM_PASSWORD]
 
                     if (
                         TYDOM_POLLING_INTERVAL in data
@@ -223,12 +212,12 @@ class Configuration:
 
         if self.is_local_mode():
             # The cloud hands out the gateway's *remote* password, which a
-            # local hub rejects. Overriding here would break a working setup.
+            # local hub rejects. Local mode pairs with the hub instead.
             logger.warning(
                 "Delta Dore cloud credentials are set but TYDOM_IP points at "
                 "a local gateway (%s). The cloud password is a different "
-                "secret and does not authenticate locally, so it is ignored. "
-                "Leave TYDOM_PASSWORD empty to pair with the hub's button.",
+                "secret and does not authenticate locally, so it is ignored: "
+                "the hub's button is used to pair instead.",
                 self.tydom_ip,
             )
             return
@@ -276,11 +265,18 @@ class Configuration:
                 # A local hub gives out its own password once its button is
                 # pressed, so this is a normal first-run state, not an error.
                 logger.info(
-                    "No Tydom password configured; will pair with the local "
-                    "hub at startup (its button will have to be pressed once)"
+                    "No stored password yet; will pair with the local hub at "
+                    "startup (its button will have to be pressed once)"
                 )
             else:
-                logger.error("Tydom password must be defined")
+                logger.error(
+                    "No password available for %s. Remote mode gets it from "
+                    "your Delta Dore account, so DELTADORE_LOGIN and "
+                    "DELTADORE_PASSWORD must be set. To connect locally "
+                    "instead, set TYDOM_IP to the hub address on your LAN and "
+                    "pair with its button.",
+                    self.tydom_ip,
+                )
                 sys.exit(1)
 
         logger.info("The configuration is valid")

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -148,6 +148,12 @@ class Configuration:
                     ):
                         self.tydom_polling_interval = int(data[TYDOM_POLLING_INTERVAL])
 
+                    if (
+                        TYDOM_PAIRING_TIMEOUT in data
+                        and data[TYDOM_PAIRING_TIMEOUT] != ""
+                    ):
+                        self.tydom_pairing_timeout = int(data[TYDOM_PAIRING_TIMEOUT])
+
                     if DELTADORE_LOGIN in data and data[DELTADORE_LOGIN] != "":
                         self.deltadore_login = data[DELTADORE_LOGIN]
 

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -74,7 +74,8 @@ class Configuration:
         # Remember whether the user supplied a password, so that neither the
         # cloud lookup nor the stored value silently overrides their choice.
         self.tydom_password_is_explicit = (
-            self.tydom_password is not None and self.tydom_password != "")
+            self.tydom_password is not None and self.tydom_password != ""
+        )
         self.password_store = PasswordStore(self.tydom_state_dir)
         self.deltadore_login = os.getenv(DELTADORE_LOGIN, None)
         self.deltadore_password = os.getenv(DELTADORE_PASSWORD, None)
@@ -100,7 +101,7 @@ class Configuration:
         return configuration
 
     def is_local_mode(self):
-        return self.tydom_ip != 'mediation.tydom.com'
+        return self.tydom_ip != "mediation.tydom.com"
 
     def resolve_local_password(self):
         """Reuse the local password kept from a previous pairing, if any.
@@ -112,7 +113,7 @@ class Configuration:
         if not self.is_local_mode():
             return
 
-        if self.tydom_password is not None and self.tydom_password != '':
+        if self.tydom_password is not None and self.tydom_password != "":
             return
 
         stored = self.password_store.read()
@@ -228,18 +229,21 @@ class Configuration:
                 "a local gateway (%s). The cloud password is a different "
                 "secret and does not authenticate locally, so it is ignored. "
                 "Leave TYDOM_PASSWORD empty to pair with the hub's button.",
-                self.tydom_ip)
+                self.tydom_ip,
+            )
             return
 
         tydom_password = TydomClient.getTydomCredentials(
-            self.deltadore_login, self.deltadore_password, self.tydom_mac)
+            self.deltadore_login, self.deltadore_password, self.tydom_mac
+        )
 
         if tydom_password is None or tydom_password == "":
             # Losing a perfectly good password because the cloud lookup failed
             # would fail validation later with a misleading message.
             logger.warning(
                 "Could not retrieve the gateway password from Delta Dore. "
-                "Keeping the configured password, if any.")
+                "Keeping the configured password, if any."
+            )
             return
 
         self.tydom_password = tydom_password
@@ -273,7 +277,8 @@ class Configuration:
                 # pressed, so this is a normal first-run state, not an error.
                 logger.info(
                     "No Tydom password configured; will pair with the local "
-                    "hub at startup (its button will have to be pressed once)")
+                    "hub at startup (its button will have to be pressed once)"
+                )
             else:
                 logger.error("Tydom password must be defined")
                 sys.exit(1)

--- a/app/configuration/Configuration.py
+++ b/app/configuration/Configuration.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 from dataclasses import dataclass
+from configuration.PasswordStore import PasswordStore
 from tydom.TydomClient import TydomClient
 
 logger = logging.getLogger(__name__)
@@ -22,6 +23,8 @@ TYDOM_IP = "TYDOM_IP"
 TYDOM_MAC = "TYDOM_MAC"
 TYDOM_PASSWORD = "TYDOM_PASSWORD"
 TYDOM_POLLING_INTERVAL = "TYDOM_POLLING_INTERVAL"
+TYDOM_STATE_DIR = "TYDOM_STATE_DIR"
+TYDOM_PAIRING_TIMEOUT = "TYDOM_PAIRING_TIMEOUT"
 DELTADORE_LOGIN = "DELTADORE_LOGIN"
 DELTADORE_PASSWORD = "DELTADORE_PASSWORD"
 THERMOSTAT_CUSTOM_PRESETS = "THERMOSTAT_CUSTOM_PRESETS"
@@ -66,6 +69,13 @@ class Configuration:
         self.tydom_mac = os.getenv(TYDOM_MAC, None)
         self.tydom_password = os.getenv(TYDOM_PASSWORD, None)
         self.tydom_polling_interval = os.getenv(TYDOM_POLLING_INTERVAL, 300)
+        self.tydom_state_dir = os.getenv(TYDOM_STATE_DIR, "/data")
+        self.tydom_pairing_timeout = os.getenv(TYDOM_PAIRING_TIMEOUT, 180)
+        # Remember whether the user supplied a password, so that neither the
+        # cloud lookup nor the stored value silently overrides their choice.
+        self.tydom_password_is_explicit = (
+            self.tydom_password is not None and self.tydom_password != "")
+        self.password_store = PasswordStore(self.tydom_state_dir)
         self.deltadore_login = os.getenv(DELTADORE_LOGIN, None)
         self.deltadore_password = os.getenv(DELTADORE_PASSWORD, None)
         self.thermostat_custom_presets = os.getenv(THERMOSTAT_CUSTOM_PRESETS, None)
@@ -85,8 +95,29 @@ class Configuration:
         configuration = Configuration()
         configuration.override_configuration_for_hassio()
         configuration.override_configuration_with_deltadore()
+        configuration.resolve_local_password()
         configuration.validate()
         return configuration
+
+    def is_local_mode(self):
+        return self.tydom_ip != 'mediation.tydom.com'
+
+    def resolve_local_password(self):
+        """Reuse the local password kept from a previous pairing, if any.
+
+        An explicitly configured password always wins, so this never
+        overrides what the user asked for. When nothing is available the
+        password stays empty and the client pairs with the hub at startup.
+        """
+        if not self.is_local_mode():
+            return
+
+        if self.tydom_password is not None and self.tydom_password != '':
+            return
+
+        stored = self.password_store.read()
+        if stored is not None:
+            self.tydom_password = stored
 
     def override_configuration_for_hassio(self):
         hassio_options_file_path = "/data/options.json"
@@ -178,16 +209,34 @@ class Configuration:
             logger.debug("Hassio environment not detected")
 
     def override_configuration_with_deltadore(self):
-        if (
-            self.deltadore_login is not None
-            and self.deltadore_login != ""
-            and self.deltadore_password is not None
-            and self.deltadore_password != ""
-        ):
-            tydom_password = TydomClient.getTydomCredentials(
-                self.deltadore_login, self.deltadore_password, self.tydom_mac
-            )
-            self.tydom_password = tydom_password
+        if self.deltadore_login is None or self.deltadore_login == "":
+            return
+        if self.deltadore_password is None or self.deltadore_password == "":
+            return
+
+        if self.is_local_mode():
+            # The cloud hands out the gateway's *remote* password, which a
+            # local hub rejects. Overriding here would break a working setup.
+            logger.warning(
+                "Delta Dore cloud credentials are set but TYDOM_IP points at "
+                "a local gateway (%s). The cloud password is a different "
+                "secret and does not authenticate locally, so it is ignored. "
+                "Leave TYDOM_PASSWORD empty to pair with the hub's button.",
+                self.tydom_ip)
+            return
+
+        tydom_password = TydomClient.getTydomCredentials(
+            self.deltadore_login, self.deltadore_password, self.tydom_mac)
+
+        if tydom_password is None or tydom_password == "":
+            # Losing a perfectly good password because the cloud lookup failed
+            # would fail validation later with a misleading message.
+            logger.warning(
+                "Could not retrieve the gateway password from Delta Dore. "
+                "Keeping the configured password, if any.")
+            return
+
+        self.tydom_password = tydom_password
 
     def validate(self):
         configuration_to_print = copy.copy(self)
@@ -213,8 +262,15 @@ class Configuration:
             sys.exit(1)
 
         if self.tydom_password is None or self.tydom_password == "":
-            logger.error("Tydom password must be defined")
-            sys.exit(1)
+            if self.is_local_mode():
+                # A local hub gives out its own password once its button is
+                # pressed, so this is a normal first-run state, not an error.
+                logger.info(
+                    "No Tydom password configured; will pair with the local "
+                    "hub at startup (its button will have to be pressed once)")
+            else:
+                logger.error("Tydom password must be defined")
+                sys.exit(1)
 
         logger.info("The configuration is valid")
 

--- a/app/configuration/PasswordStore.py
+++ b/app/configuration/PasswordStore.py
@@ -1,0 +1,77 @@
+import logging
+import os
+import stat
+
+logger = logging.getLogger(__name__)
+
+PASSWORD_FILENAME = "tydom_local_password"
+
+
+class PasswordStore:
+    """Persist the gateway's local password outside of the configuration.
+
+    A Tydom hub hands out its local password only during the window that
+    follows a press on its physical button. Storing the discovered value lets
+    the app reconnect on its own afterwards, so the password never has to be
+    written into the add-on options, a compose file or an environment
+    variable.
+
+    In a Home Assistant add-on /data is persistent, so this is transparent.
+    Under plain `docker run` it is not, unless a volume is mounted: the path
+    actually used is logged on every write so a non-persistent setup is
+    obvious immediately rather than discovered weeks later.
+    """
+
+    def __init__(self, directory):
+        self.directory = directory
+        self.path = os.path.join(directory, PASSWORD_FILENAME)
+
+    def read(self):
+        """Return the stored password, or None when there is nothing usable."""
+        try:
+            with open(self.path) as stored:
+                password = stored.read().strip()
+        except FileNotFoundError:
+            return None
+        except OSError as e:
+            logger.warning("Cannot read the stored Tydom password (%s)", e)
+            return None
+
+        if password == "":
+            return None
+
+        logger.info("Using the Tydom local password stored in %s", self.path)
+        return password
+
+    def write(self, password):
+        """Store the password, readable by its owner only.
+
+        Returns True when the value was persisted. A failure is not fatal:
+        the app can still run with the password it just discovered, it will
+        simply need the button again on the next start.
+        """
+        try:
+            os.makedirs(self.directory, exist_ok=True)
+            with open(self.path, "w") as stored:
+                stored.write(password)
+            os.chmod(self.path, stat.S_IRUSR | stat.S_IWUSR)
+        except OSError as e:
+            logger.warning(
+                "Could not store the Tydom local password in %s (%s). "
+                "The hub's button will be needed again on the next start.",
+                self.path, e)
+            return False
+
+        logger.info("Tydom local password stored in %s", self.path)
+        return True
+
+    def clear(self):
+        """Forget the stored password, so pairing starts over."""
+        try:
+            os.remove(self.path)
+            logger.info("Discarded the stored Tydom local password (%s)",
+                        self.path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.warning("Could not discard %s (%s)", self.path, e)

--- a/app/configuration/PasswordStore.py
+++ b/app/configuration/PasswordStore.py
@@ -59,7 +59,9 @@ class PasswordStore:
             logger.warning(
                 "Could not store the Tydom local password in %s (%s). "
                 "The hub's button will be needed again on the next start.",
-                self.path, e)
+                self.path,
+                e,
+            )
             return False
 
         logger.info("Tydom local password stored in %s", self.path)
@@ -69,8 +71,7 @@ class PasswordStore:
         """Forget the stored password, so pairing starts over."""
         try:
             os.remove(self.path)
-            logger.info("Discarded the stored Tydom local password (%s)",
-                        self.path)
+            logger.info("Discarded the stored Tydom local password (%s)", self.path)
         except FileNotFoundError:
             pass
         except OSError as e:

--- a/app/main.py
+++ b/app/main.py
@@ -117,6 +117,8 @@ tydom_client = TydomClient(
     thermostat_heat_mode_temp_default=configuration.thermostat_heat_mode_temp_default,
     alarm_pin=configuration.tydom_alarm_pin,
     thermostat_custom_presets=configuration.thermostat_custom_presets,
+    password_store=configuration.password_store,
+    pairing_timeout=configuration.tydom_pairing_timeout,
 )
 
 # Create mqtt client

--- a/app/tools/get_local_password.py
+++ b/app/tools/get_local_password.py
@@ -49,29 +49,40 @@ async def read_password(host, mac, timeout):
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Read a Tydom hub's local password (one-time pairing).")
-    parser.add_argument("--host", required=True,
-                        help="gateway IP address on your LAN")
-    parser.add_argument("--mac", required=True,
-                        help="gateway MAC address, e.g. 001A25XXXXXX")
-    parser.add_argument("--timeout", type=int, default=120,
-                        help="how long to wait for the button press (seconds)")
+        description="Read a Tydom hub's local password (one-time pairing)."
+    )
+    parser.add_argument("--host", required=True, help="gateway IP address on your LAN")
+    parser.add_argument(
+        "--mac", required=True, help="gateway MAC address, e.g. 001A25XXXXXX"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=120,
+        help="how long to wait for the button press (seconds)",
+    )
     args = parser.parse_args()
 
     print(f"Connecting to {args.host} ({args.mac}).")
-    print("Press the button on the Tydom hub now; waiting up to "
-          f"{args.timeout}s for its pairing window.\n")
+    print(
+        "Press the button on the Tydom hub now; waiting up to "
+        f"{args.timeout}s for its pairing window.\n"
+    )
 
     password = asyncio.run(read_password(args.host, args.mac, args.timeout))
 
     if password is None:
-        print("\nCould not read the password. Make sure you pressed the "
-              "button on the hub, and that the MAC and IP are correct.")
+        print(
+            "\nCould not read the password. Make sure you pressed the "
+            "button on the hub, and that the MAC and IP are correct."
+        )
         sys.exit(1)
 
     print(f"\nLocal password: {password}")
-    print("Do not use the Delta Dore cloud password for a local connection: "
-          "it is a different secret.")
+    print(
+        "Do not use the Delta Dore cloud password for a local connection: "
+        "it is a different secret."
+    )
 
 
 if __name__ == "__main__":

--- a/app/tools/get_local_password.py
+++ b/app/tools/get_local_password.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Read a Tydom hub's *local* password by pairing with it once.
+
+Why this exists
+---------------
+The password returned by the Delta Dore cloud API (the one tydom2mqtt fetches
+from DELTADORE_LOGIN / DELTADORE_PASSWORD) is **not** the password the gateway
+expects for a direct LAN connection: they are two different secrets. Using the
+cloud one against a local gateway fails with a permanent HTTP 401 that looks
+exactly like a wrong configuration.
+
+The gateway exposes its local password on /configs/gateway/password, but only
+accepts an unauthenticated connection during the short window that follows a
+press on its physical button. This tool waits for that window, reads the
+password once, and prints it. Put the value in TYDOM_PASSWORD and you are done:
+subsequent connections authenticate normally, no further button press.
+
+Usage
+-----
+    python tools/get_local_password.py --host 192.168.1.33 --mac 001A25XXXXXX
+"""
+
+import argparse
+import asyncio
+import json
+import re
+import ssl
+import sys
+import time
+
+import websockets
+
+RETRY_DELAY = 3
+
+
+def dechunk(body):
+    """Decode an HTTP chunked-transfer body into its payload."""
+    payload = ""
+    lines = body.split("\r\n")
+    index = 0
+    while index < len(lines):
+        line = lines[index].strip()
+        index += 1
+        if not line:
+            continue
+        if not re.fullmatch(r"[0-9a-fA-F]+", line):
+            # Not a chunk header: the gateway is not always strict, keep the
+            # line as payload rather than dropping data.
+            payload += line
+            continue
+        if int(line, 16) == 0:
+            break
+        if index < len(lines):
+            payload += lines[index]
+            index += 1
+    return payload
+
+
+def extract_password(response):
+    """Pull the password out of a /configs/gateway/password response."""
+    separator = response.find("\r\n\r\n")
+    body = response[separator + 4:] if separator != -1 else response
+    payload = dechunk(body)
+    try:
+        return json.loads(payload)["current"]
+    except (ValueError, KeyError):
+        return None
+
+
+async def read_password(host, mac, timeout):
+    ssl_context = ssl._create_unverified_context()
+    ssl_context.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
+
+    url = f"wss://{host}:443/mediation/client?mac={mac}&appli=1"
+    deadline = time.monotonic() + timeout
+    attempt = 0
+
+    while time.monotonic() < deadline:
+        attempt += 1
+        try:
+            connection = await websockets.connect(
+                url,
+                extra_headers={"Sec-WebSocket-Version": "13"},
+                ssl=ssl_context,
+                ping_timeout=None,
+            )
+        except Exception as e:
+            status = getattr(e, "status_code", None)
+            if status == 401:
+                print(f"  attempt {attempt}: gateway still locked, "
+                      "press its button now...")
+            else:
+                print(f"  attempt {attempt}: {e}")
+            await asyncio.sleep(RETRY_DELAY)
+            continue
+
+        print("Pairing window is open, reading the password...")
+        request = (
+            "GET /configs/gateway/password HTTP/1.1\r\n"
+            "Content-Length: 0\r\n"
+            "Content-Type: application/json; charset=UTF-8\r\n"
+            "Transac-Id: 0\r\n\r\n"
+        )
+        await connection.send(request.encode("ascii"))
+        try:
+            # The gateway also pushes unsolicited events; skip them until the
+            # answer to our own request shows up.
+            for _ in range(5):
+                reply = await asyncio.wait_for(connection.recv(), timeout=5)
+                text = reply if isinstance(reply, str) else reply.decode(
+                    errors="replace")
+                if "/configs/gateway/password" in text:
+                    return extract_password(text)
+        except asyncio.TimeoutError:
+            print("  the gateway did not answer, retrying...")
+        finally:
+            await connection.close()
+
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read a Tydom hub's local password (one-time pairing).")
+    parser.add_argument("--host", required=True,
+                        help="gateway IP address on your LAN")
+    parser.add_argument("--mac", required=True,
+                        help="gateway MAC address, e.g. 001A25XXXXXX")
+    parser.add_argument("--timeout", type=int, default=120,
+                        help="how long to wait for the button press (seconds)")
+    args = parser.parse_args()
+
+    print(f"Connecting to {args.host} ({args.mac}).")
+    print("Press the button on the Tydom hub now; waiting up to "
+          f"{args.timeout}s for its pairing window.\n")
+
+    password = asyncio.run(
+        read_password(args.host, args.mac, args.timeout))
+
+    if password is None:
+        print("\nCould not read the password. Make sure you pressed the "
+              "button on the hub, and that the MAC and IP are correct.")
+        sys.exit(1)
+
+    print(f"\nLocal password: {password}")
+    print("Set it as TYDOM_PASSWORD. Do not use the Delta Dore cloud password "
+          "for a local connection: it is a different secret.")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/tools/get_local_password.py
+++ b/app/tools/get_local_password.py
@@ -1,19 +1,17 @@
 #!/usr/bin/env python3
 """Read a Tydom hub's *local* password by pairing with it once.
 
-Why this exists
----------------
-The password returned by the Delta Dore cloud API (the one tydom2mqtt fetches
-from DELTADORE_LOGIN / DELTADORE_PASSWORD) is **not** the password the gateway
-expects for a direct LAN connection: they are two different secrets. Using the
-cloud one against a local gateway fails with a permanent HTTP 401 that looks
-exactly like a wrong configuration.
+tydom2mqtt normally does this on its own: start it with no TYDOM_PASSWORD in
+local mode, press the hub's button when asked, and it stores the password for
+you. This tool is the manual equivalent, useful to inspect the value or to
+recover it without running the app.
 
-The gateway exposes its local password on /configs/gateway/password, but only
-accepts an unauthenticated connection during the short window that follows a
-press on its physical button. This tool waits for that window, reads the
-password once, and prints it. Put the value in TYDOM_PASSWORD and you are done:
-subsequent connections authenticate normally, no further button press.
+Why the password matters
+------------------------
+The password the Delta Dore cloud API returns for a gateway is *not* the one
+that gateway expects on a direct LAN connection: they are two different
+secrets. Using the cloud one locally fails with a permanent HTTP 401 that
+looks exactly like a misconfiguration.
 
 Usage
 -----
@@ -22,99 +20,29 @@ Usage
 
 import argparse
 import asyncio
-import json
-import re
+import os
 import ssl
 import sys
 import time
 
-import websockets
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-RETRY_DELAY = 3
-
-
-def dechunk(body):
-    """Decode an HTTP chunked-transfer body into its payload."""
-    payload = ""
-    lines = body.split("\r\n")
-    index = 0
-    while index < len(lines):
-        line = lines[index].strip()
-        index += 1
-        if not line:
-            continue
-        if not re.fullmatch(r"[0-9a-fA-F]+", line):
-            # Not a chunk header: the gateway is not always strict, keep the
-            # line as payload rather than dropping data.
-            payload += line
-            continue
-        if int(line, 16) == 0:
-            break
-        if index < len(lines):
-            payload += lines[index]
-            index += 1
-    return payload
-
-
-def extract_password(response):
-    """Pull the password out of a /configs/gateway/password response."""
-    separator = response.find("\r\n\r\n")
-    body = response[separator + 4:] if separator != -1 else response
-    payload = dechunk(body)
-    try:
-        return json.loads(payload)["current"]
-    except (ValueError, KeyError):
-        return None
+from tydom.TydomClient import TydomClient, PAIRING_RETRY_DELAY  # noqa: E402
 
 
 async def read_password(host, mac, timeout):
     ssl_context = ssl._create_unverified_context()
     ssl_context.options |= 0x4  # OP_LEGACY_SERVER_CONNECT
 
-    url = f"wss://{host}:443/mediation/client?mac={mac}&appli=1"
     deadline = time.monotonic() + timeout
     attempt = 0
-
     while time.monotonic() < deadline:
         attempt += 1
-        try:
-            connection = await websockets.connect(
-                url,
-                extra_headers={"Sec-WebSocket-Version": "13"},
-                ssl=ssl_context,
-                ping_timeout=None,
-            )
-        except Exception as e:
-            status = getattr(e, "status_code", None)
-            if status == 401:
-                print(f"  attempt {attempt}: gateway still locked, "
-                      "press its button now...")
-            else:
-                print(f"  attempt {attempt}: {e}")
-            await asyncio.sleep(RETRY_DELAY)
-            continue
-
-        print("Pairing window is open, reading the password...")
-        request = (
-            "GET /configs/gateway/password HTTP/1.1\r\n"
-            "Content-Length: 0\r\n"
-            "Content-Type: application/json; charset=UTF-8\r\n"
-            "Transac-Id: 0\r\n\r\n"
-        )
-        await connection.send(request.encode("ascii"))
-        try:
-            # The gateway also pushes unsolicited events; skip them until the
-            # answer to our own request shows up.
-            for _ in range(5):
-                reply = await asyncio.wait_for(connection.recv(), timeout=5)
-                text = reply if isinstance(reply, str) else reply.decode(
-                    errors="replace")
-                if "/configs/gateway/password" in text:
-                    return extract_password(text)
-        except asyncio.TimeoutError:
-            print("  the gateway did not answer, retrying...")
-        finally:
-            await connection.close()
+        password = await TydomClient.read_local_password(host, mac, ssl_context)
+        if password is not None:
+            return password
+        print(f"  attempt {attempt}: hub still locked, press its button now...")
+        await asyncio.sleep(PAIRING_RETRY_DELAY)
 
     return None
 
@@ -134,8 +62,7 @@ def main():
     print("Press the button on the Tydom hub now; waiting up to "
           f"{args.timeout}s for its pairing window.\n")
 
-    password = asyncio.run(
-        read_password(args.host, args.mac, args.timeout))
+    password = asyncio.run(read_password(args.host, args.mac, args.timeout))
 
     if password is None:
         print("\nCould not read the password. Make sure you pressed the "
@@ -143,8 +70,8 @@ def main():
         sys.exit(1)
 
     print(f"\nLocal password: {password}")
-    print("Set it as TYDOM_PASSWORD. Do not use the Delta Dore cloud password "
-          "for a local connection: it is a different secret.")
+    print("Do not use the Delta Dore cloud password for a local connection: "
+          "it is a different secret.")
 
 
 if __name__ == "__main__":

--- a/app/tools/get_local_password.py
+++ b/app/tools/get_local_password.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Read a Tydom hub's *local* password by pairing with it once.
 
-tydom2mqtt normally does this on its own: start it with no TYDOM_PASSWORD in
-local mode, press the hub's button when asked, and it stores the password for
-you. This tool is the manual equivalent, useful to inspect the value or to
-recover it without running the app.
+tydom2mqtt normally does this on its own: start it in local mode, press the
+hub's button when asked, and it stores the password for you. This tool is the
+manual equivalent, useful to inspect the value or to recover it without
+running the app.
 
 Why the password matters
 ------------------------

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import http.client
 import json
@@ -6,6 +7,7 @@ import os
 import re
 import ssl
 import sys
+import time
 
 import websockets
 import requests
@@ -23,6 +25,11 @@ from health.HealthState import HealthState
 
 logger = logging.getLogger(__name__)
 
+# How long to wait for someone to press the hub's button, and how often to
+# retry while waiting.
+DEFAULT_PAIRING_TIMEOUT = 180
+PAIRING_RETRY_DELAY = 3
+
 
 class TydomClient:
     def __init__(
@@ -35,6 +42,8 @@ class TydomClient:
         host=MEDIATION_URL,
         alarm_pin=None,
         thermostat_custom_presets=None,
+        password_store=None,
+        pairing_timeout=DEFAULT_PAIRING_TIMEOUT,
     ):
         logger.debug("Initializing TydomClient Class")
 
@@ -42,6 +51,8 @@ class TydomClient:
         self.mac = mac
         self.host = host
         self.alarm_pin = alarm_pin
+        self.password_store = password_store
+        self.pairing_timeout = int(pairing_timeout)
         self.connection = None
         self.remote_mode = True
         self.ssl_context = None
@@ -139,8 +150,125 @@ class TydomClient:
             logger.info(e)
             return None
 
-    async def connect(self):
-        logger.info("Connecting to tydom")
+    @staticmethod
+    async def read_local_password(host, mac, ssl_context):
+        """Read the gateway's local password, if its pairing window is open.
+
+        A Tydom hub accepts an unauthenticated connection only during the
+        short window that follows a press on its physical button, and serves
+        its own local password on /configs/gateway/password. Outside that
+        window it answers 401 and this returns None.
+
+        Note that this password is a different secret from the one the Delta
+        Dore cloud API returns for the same gateway: the cloud one does not
+        authenticate a local connection.
+        """
+        try:
+            connection = await websockets.connect(
+                f"wss://{host}:443/mediation/client?mac={mac}&appli=1",
+                additional_headers={"Sec-WebSocket-Version": "13"},
+                ssl=ssl_context,
+                ping_timeout=None,
+            )
+        except Exception:
+            # Still locked, or unreachable; the caller decides whether to
+            # keep waiting.
+            return None
+
+        try:
+            request = (
+                "GET /configs/gateway/password HTTP/1.1\r\n"
+                "Content-Length: 0\r\n"
+                "Content-Type: application/json; charset=UTF-8\r\n"
+                "Transac-Id: 0\r\n\r\n"
+            )
+            await connection.send(request.encode("ascii"))
+            # The hub also pushes unsolicited events, so skip anything that is
+            # not the answer to this request.
+            for _ in range(5):
+                reply = await asyncio.wait_for(connection.recv(), timeout=5)
+                text = reply if isinstance(reply, str) else reply.decode(
+                    errors="replace")
+                if "/configs/gateway/password" in text:
+                    return TydomClient.extract_password(text)
+            return None
+        except Exception as e:
+            logger.warning("Could not read the local password (%s)", e)
+            return None
+        finally:
+            await connection.close()
+
+    @staticmethod
+    def extract_password(response):
+        """Pull the password out of a /configs/gateway/password response."""
+        separator = response.find("\r\n\r\n")
+        body = response[separator + 4:] if separator != -1 else response
+
+        payload = ""
+        lines = body.split("\r\n")
+        index = 0
+        while index < len(lines):
+            line = lines[index].strip()
+            index += 1
+            if not line:
+                continue
+            # Chunked transfer encoding: a hex length, then that chunk.
+            if not re.fullmatch(r"[0-9a-fA-F]+", line):
+                payload += line
+                continue
+            if int(line, 16) == 0:
+                break
+            if index < len(lines):
+                payload += lines[index]
+                index += 1
+
+        try:
+            return json.loads(payload)["current"]
+        except (ValueError, KeyError):
+            return None
+
+    async def pair_locally(self):
+        """Wait for the hub's button to be pressed, then keep its password.
+
+        Returns True once a password has been obtained.
+        """
+        logger.warning(
+            "No usable local password for the Tydom hub at %s. "
+            "PRESS THE BUTTON ON THE HUB NOW: it will be read automatically "
+            "and stored, and will not be asked for again. Waiting up to %ss.",
+            self.host, self.pairing_timeout)
+
+        deadline = time.monotonic() + self.pairing_timeout
+        while time.monotonic() < deadline:
+            password = await self.read_local_password(
+                self.host, self.mac, self.ssl_context)
+            if password is not None:
+                logger.info("Paired with the Tydom hub, local password read")
+                self.password = password
+                if self.password_store is not None:
+                    self.password_store.write(password)
+                return True
+            remaining = int(deadline - time.monotonic())
+            logger.info(
+                "Hub still locked, press its button (%ss left)", max(remaining, 0))
+            await asyncio.sleep(PAIRING_RETRY_DELAY)
+
+        return False
+
+    async def connect(self, allow_pairing=True):
+        logger.info('Connecting to tydom')
+
+        # A local hub can hand out its own password once its button is
+        # pressed, so an empty password is not a fatal configuration error
+        # there: pair first, then connect with what we were given.
+        if not self.remote_mode and not self.password and allow_pairing:
+            if not await self.pair_locally():
+                logger.error(
+                    "Nobody pressed the button on the Tydom hub, so no local "
+                    "password could be obtained. Restart and press it to "
+                    "pair, or set TYDOM_PASSWORD explicitly.")
+                sys.exit(1)
+
         http_headers = {
             "Connection": "Upgrade",
             "Upgrade": "websocket",
@@ -206,18 +334,35 @@ class TydomClient:
             self.health_state.update_tydom_status(True)
             return self.connection
         except websockets.exceptions.InvalidStatusCode as e:
-            if e.status_code == 401:
-                logger.error(
-                    "Tydom rejected the credentials (HTTP 401). The gateway's "
-                    "local password is NOT the one returned by the Delta Dore "
-                    "cloud API: they are two different secrets. Press the "
-                    "button on the Tydom hub, then read the local one with "
-                    "'python tools/get_local_password.py --host %s --mac %s'.",
-                    self.host, self.mac)
-            else:
+            if e.status_code != 401:
                 logger.error(
                     "Tydom rejected the websocket handshake (HTTP %s)",
                     e.status_code)
+                sys.exit(1)
+
+            # The credentials were refused. On a local hub they may simply
+            # have gone stale (hub reset, password changed), so forget them
+            # and pair again rather than requiring manual intervention.
+            if not self.remote_mode and allow_pairing:
+                logger.warning(
+                    "The Tydom hub refused the local password (HTTP 401). "
+                    "Discarding it and pairing again.")
+                if self.password_store is not None:
+                    self.password_store.clear()
+                self.password = None
+                if await self.pair_locally():
+                    # allow_pairing=False so a second refusal is reported
+                    # instead of looping on the button forever.
+                    return await self.connect(allow_pairing=False)
+                logger.error(
+                    "Nobody pressed the button on the Tydom hub, so the "
+                    "local password could not be renewed.")
+                sys.exit(1)
+
+            logger.error(
+                "Tydom rejected the credentials (HTTP 401). The gateway's "
+                "local password is NOT the one returned by the Delta Dore "
+                "cloud API: they are two different secrets.")
             sys.exit(1)
         except Exception as e:
             logger.error("Exception when trying to connect with websocket (%s)", e)

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -187,8 +187,9 @@ class TydomClient:
             # not the answer to this request.
             for _ in range(5):
                 reply = await asyncio.wait_for(connection.recv(), timeout=5)
-                text = reply if isinstance(reply, str) else reply.decode(
-                    errors="replace")
+                text = (
+                    reply if isinstance(reply, str) else reply.decode(errors="replace")
+                )
                 if "/configs/gateway/password" in text:
                     return TydomClient.extract_password(text)
             return None
@@ -202,7 +203,7 @@ class TydomClient:
     def extract_password(response):
         """Pull the password out of a /configs/gateway/password response."""
         separator = response.find("\r\n\r\n")
-        body = response[separator + 4:] if separator != -1 else response
+        body = response[separator + 4 :] if separator != -1 else response
 
         payload = ""
         lines = body.split("\r\n")
@@ -236,12 +237,15 @@ class TydomClient:
             "No usable local password for the Tydom hub at %s. "
             "PRESS THE BUTTON ON THE HUB NOW: it will be read automatically "
             "and stored, and will not be asked for again. Waiting up to %ss.",
-            self.host, self.pairing_timeout)
+            self.host,
+            self.pairing_timeout,
+        )
 
         deadline = time.monotonic() + self.pairing_timeout
         while time.monotonic() < deadline:
             password = await self.read_local_password(
-                self.host, self.mac, self.ssl_context)
+                self.host, self.mac, self.ssl_context
+            )
             if password is not None:
                 logger.info("Paired with the Tydom hub, local password read")
                 self.password = password
@@ -250,13 +254,14 @@ class TydomClient:
                 return True
             remaining = int(deadline - time.monotonic())
             logger.info(
-                "Hub still locked, press its button (%ss left)", max(remaining, 0))
+                "Hub still locked, press its button (%ss left)", max(remaining, 0)
+            )
             await asyncio.sleep(PAIRING_RETRY_DELAY)
 
         return False
 
     async def connect(self, allow_pairing=True):
-        logger.info('Connecting to tydom')
+        logger.info("Connecting to tydom")
 
         # A local hub can hand out its own password once its button is
         # pressed, so an empty password is not a fatal configuration error
@@ -266,7 +271,8 @@ class TydomClient:
                 logger.error(
                     "Nobody pressed the button on the Tydom hub, so no local "
                     "password could be obtained. Restart and press it to "
-                    "pair, or set TYDOM_PASSWORD explicitly.")
+                    "pair, or set TYDOM_PASSWORD explicitly."
+                )
                 sys.exit(1)
 
         http_headers = {
@@ -307,8 +313,7 @@ class TydomClient:
             # A gateway in its pairing window answers without challenging, so
             # only authenticate when we were actually challenged.
             challenge = self.parse_digest_challenge(www_authenticate)
-            websocket_headers = {
-                "Authorization": self.build_digest_headers(challenge)}
+            websocket_headers = {"Authorization": self.build_digest_headers(challenge)}
 
         logger.debug("Upgrading http connection to websocket....")
 
@@ -336,8 +341,8 @@ class TydomClient:
         except websockets.exceptions.InvalidStatusCode as e:
             if e.status_code != 401:
                 logger.error(
-                    "Tydom rejected the websocket handshake (HTTP %s)",
-                    e.status_code)
+                    "Tydom rejected the websocket handshake (HTTP %s)", e.status_code
+                )
                 sys.exit(1)
 
             # The credentials were refused. On a local hub they may simply
@@ -346,7 +351,8 @@ class TydomClient:
             if not self.remote_mode and allow_pairing:
                 logger.warning(
                     "The Tydom hub refused the local password (HTTP 401). "
-                    "Discarding it and pairing again.")
+                    "Discarding it and pairing again."
+                )
                 if self.password_store is not None:
                     self.password_store.clear()
                 self.password = None
@@ -356,13 +362,15 @@ class TydomClient:
                     return await self.connect(allow_pairing=False)
                 logger.error(
                     "Nobody pressed the button on the Tydom hub, so the "
-                    "local password could not be renewed.")
+                    "local password could not be renewed."
+                )
                 sys.exit(1)
 
             logger.error(
                 "Tydom rejected the credentials (HTTP 401). The gateway's "
                 "local password is NOT the one returned by the Delta Dore "
-                "cloud API: they are two different secrets.")
+                "cloud API: they are two different secrets."
+            )
             sys.exit(1)
         except Exception as e:
             logger.error("Exception when trying to connect with websocket (%s)", e)
@@ -395,7 +403,8 @@ class TydomClient:
         return {
             key: quoted or unquoted
             for key, quoted, unquoted in re.findall(
-                r'(\w+)=(?:"([^"]*)"|([^,\s]+))', header_value)
+                r'(\w+)=(?:"([^"]*)"|([^,\s]+))', header_value
+            )
         }
 
     # Build the headers of Digest Authentication

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -271,7 +271,7 @@ class TydomClient:
                 logger.error(
                     "Nobody pressed the button on the Tydom hub, so no local "
                     "password could be obtained. Restart and press it to "
-                    "pair, or set TYDOM_PASSWORD explicitly."
+                    "pair."
                 )
                 sys.exit(1)
 

--- a/app/tydom/TydomClient.py
+++ b/app/tydom/TydomClient.py
@@ -3,6 +3,7 @@ import http.client
 import json
 import logging
 import os
+import re
 import ssl
 import sys
 
@@ -173,15 +174,13 @@ class TydomClient:
 
         # Get authentication
         websocket_headers = {}
-        try:
-            # Local installations are unauthenticated but we don't *know* that for certain
-            # so we'll EAFP, try to use the header and fallback if we're
-            # unable.
-            nonce = res.headers["WWW-Authenticate"].split(",", 3)
-            # Build websocket headers
-            websocket_headers = {"Authorization": self.build_digest_headers(nonce)}
-        except AttributeError:
-            pass
+        www_authenticate = res.headers["WWW-Authenticate"]
+        if www_authenticate is not None:
+            # A gateway in its pairing window answers without challenging, so
+            # only authenticate when we were actually challenged.
+            challenge = self.parse_digest_challenge(www_authenticate)
+            websocket_headers = {
+                "Authorization": self.build_digest_headers(challenge)}
 
         logger.debug("Upgrading http connection to websocket....")
 
@@ -206,6 +205,20 @@ class TydomClient:
             logger.info("Connected to tydom")
             self.health_state.update_tydom_status(True)
             return self.connection
+        except websockets.exceptions.InvalidStatusCode as e:
+            if e.status_code == 401:
+                logger.error(
+                    "Tydom rejected the credentials (HTTP 401). The gateway's "
+                    "local password is NOT the one returned by the Delta Dore "
+                    "cloud API: they are two different secrets. Press the "
+                    "button on the Tydom hub, then read the local one with "
+                    "'python tools/get_local_password.py --host %s --mac %s'.",
+                    self.host, self.mac)
+            else:
+                logger.error(
+                    "Tydom rejected the websocket handshake (HTTP %s)",
+                    e.status_code)
+            sys.exit(1)
         except Exception as e:
             logger.error("Exception when trying to connect with websocket (%s)", e)
             sys.exit(1)
@@ -223,16 +236,35 @@ class TydomClient:
     def generate_random_key():
         return base64.b64encode(os.urandom(16))
 
+    @staticmethod
+    def parse_digest_challenge(header_value):
+        """Parse a "WWW-Authenticate: Digest ..." header into its directives.
+
+        The realm must be echoed back exactly as the gateway sent it: it feeds
+        the digest response hash (HA1 = MD5(username:realm:password)), so a
+        hardcoded realm silently produces a response that never matches, even
+        with the correct password. Recent Tydom firmwares answer with
+        realm="Protected Area", which no longer matches the value that used to
+        be hardcoded here.
+        """
+        return {
+            key: quoted or unquoted
+            for key, quoted, unquoted in re.findall(
+                r'(\w+)=(?:"([^"]*)"|([^,\s]+))', header_value)
+        }
+
     # Build the headers of Digest Authentication
-    def build_digest_headers(self, nonce):
+    def build_digest_headers(self, challenge):
         digest_auth = HTTPDigestAuth(self.mac, self.password)
         chal = dict()
-        chal["nonce"] = nonce[2].split("=", 1)[1].split('"')[1]
-        chal["realm"] = "ServiceMedia" if self.remote_mode is True else "protected area"
-        chal["qop"] = "auth"
+        chal["nonce"] = challenge["nonce"]
+        chal["realm"] = challenge["realm"]
+        chal["qop"] = challenge.get("qop", "auth")
+        if "opaque" in challenge:
+            chal["opaque"] = challenge["opaque"]
         digest_auth._thread_local.chal = chal
-        digest_auth._thread_local.last_nonce = nonce
-        digest_auth._thread_local.nonce_count = 1
+        digest_auth._thread_local.last_nonce = ""
+        digest_auth._thread_local.nonce_count = 0
         return digest_auth.build_digest_header(
             "GET",
             "https://{host}:443/mediation/client?mac={mac}&appli=1".format(

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -3,19 +3,22 @@
 
 ## Environment variables
 
-You need one of the following to authenticate: `TYDOM_PASSWORD`, `DELTADORE_LOGIN` +
-`DELTADORE_PASSWORD` (your Delta Dore account is used to retrieve the Tydom
-password), or nothing at all when `TYDOM_IP` points at a hub on your LAN — in
-that case `tydom2mqtt` pairs with the hub instead: on the first start it asks
-you to press the button on the hub, reads the local password it hands out,
-and stores it under `TYDOM_STATE_DIR`. The button is only needed that once.
+There is no password to configure.
+
+Set `TYDOM_IP` to your hub's address on the LAN (recommended). On the first
+start `tydom2mqtt` asks you to press the button on the hub, reads the hub's
+own local password, and stores it under `TYDOM_STATE_DIR`. The button is only
+needed that once.
+
+Without `TYDOM_IP` the connection goes through Delta Dore's relay, which has
+no button to press: `DELTADORE_LOGIN` and `DELTADORE_PASSWORD` are then
+required so the password can be fetched from your account.
 
 | Environment variable              | Required       | Supported values                                                                                                                                                                                                           | Default value when missing |
 |-----------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
 | TYDOM_MAC                         | :red_circle:   | Tydom MAC address (starting with `001A...`)                                                                                                                                                                                |                            |
-| DELTADORE_LOGIN                   | :white_circle: | Delta Dore account login                                                                                                                                                                                                   |                            |
-| DELTADORE_PASSWORD                | :white_circle: | Delta Dore account password                                                                                                                                                                                                |                            |
-| TYDOM_PASSWORD                    | :white_circle: | Tydom password. Not needed for a local connection, see above                                                                                                                                                              |                            |
+| DELTADORE_LOGIN                   | :white_circle: | Delta Dore account login. Required in remote mode only (no `TYDOM_IP`)                                                                                                                                                     |                            |
+| DELTADORE_PASSWORD                | :white_circle: | Delta Dore account password. Required in remote mode only (no `TYDOM_IP`)                                                                                                                                                  |                            |
 | TYDOM_IP                          | :white_circle: | Tydom IPv4 address or FQDN. Set it to connect locally and pair with the hub's button                                                                                                                                       | `mediation.tydom.com`      |
 | TYDOM_STATE_DIR                   | :white_circle: | Where the local password obtained by pairing is stored. Must be persistent, otherwise the button is needed on every start                                                                                                   | `/data`                    |
 | TYDOM_PAIRING_TIMEOUT             | :white_circle: | How long to wait for the hub's button at startup, in seconds                                                                                                                                                               | `180`                      |
@@ -35,35 +38,9 @@ and stores it under `TYDOM_STATE_DIR`. The button is only needed that once.
 
 ## Complete example
 
-Using a Tydom password (works locally or through the Delta Dore relay):
-
-<!-- tabs:start -->
-#### **Docker Compose**
-```yaml
-version: '3'
-
-services:
-  tydom2mqtt:
-    image: ghcr.io/tydom2mqtt/tydom2mqtt
-    container_name: tydom2mqtt
-    environment:
-      - TYDOM_MAC=001A25XXXXXX
-      - TYDOM_PASSWORD=azerty123456789
-      - TYDOM_IP=192.168.1.33
-```
-#### **Docker**
-```bash
-docker run -d --name tydom2mqtt \
-  -e TYDOM_MAC="001A25XXXXXX" \
-  -e TYDOM_PASSWORD="azerty123456789" \
-  -e TYDOM_IP="192.168.1.33" \  
-  ghcr.io/tydom2mqtt/tydom2mqtt
-```
-<!-- tabs:end -->
-
-Or, for a local connection, pairing with the hub's button instead (a
+For a local connection (recommended), pairing with the hub's button. A
 persistent volume on `/data` is required, otherwise the button is needed on
-every start):
+every start:
 
 <!-- tabs:start -->
 #### **Docker Compose**
@@ -86,6 +63,32 @@ docker run -d --name tydom2mqtt \
   -e TYDOM_MAC="001A25XXXXXX" \
   -e TYDOM_IP="192.168.1.33" \
   -v "$(pwd)/tydom-data:/data" \
+  ghcr.io/tydom2mqtt/tydom2mqtt
+```
+<!-- tabs:end -->
+
+Or through the Delta Dore relay, with your account credentials:
+
+<!-- tabs:start -->
+#### **Docker Compose**
+```yaml
+version: '3'
+
+services:
+  tydom2mqtt:
+    image: ghcr.io/tydom2mqtt/tydom2mqtt
+    container_name: tydom2mqtt
+    environment:
+      - TYDOM_MAC=001A25XXXXXX
+      - DELTADORE_LOGIN=your@email.com
+      - DELTADORE_PASSWORD=your-delta-dore-password
+```
+#### **Docker**
+```bash
+docker run -d --name tydom2mqtt \
+  -e TYDOM_MAC="001A25XXXXXX" \
+  -e DELTADORE_LOGIN="your@email.com" \
+  -e DELTADORE_PASSWORD="your-delta-dore-password" \
   ghcr.io/tydom2mqtt/tydom2mqtt
 ```
 <!-- tabs:end -->

--- a/docs/configuration/README.md
+++ b/docs/configuration/README.md
@@ -3,15 +3,22 @@
 
 ## Environment variables
 
-Please note that only one of DELTADORE_LOGIN + DELTADORE_PASSWORD or TYDOM_PASSWORD is needed as your Delta Dore account is used to retrieve the Tydom password
+You need one of the following to authenticate: `TYDOM_PASSWORD`, `DELTADORE_LOGIN` +
+`DELTADORE_PASSWORD` (your Delta Dore account is used to retrieve the Tydom
+password), or nothing at all when `TYDOM_IP` points at a hub on your LAN — in
+that case `tydom2mqtt` pairs with the hub instead: on the first start it asks
+you to press the button on the hub, reads the local password it hands out,
+and stores it under `TYDOM_STATE_DIR`. The button is only needed that once.
 
 | Environment variable              | Required       | Supported values                                                                                                                                                                                                           | Default value when missing |
 |-----------------------------------|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------|
 | TYDOM_MAC                         | :red_circle:   | Tydom MAC address (starting with `001A...`)                                                                                                                                                                                |                            |
-| DELTADORE_LOGIN                   | :red_circle:   | Delta Dore account login                                                                                                                                                                                                   |                            |
-| DELTADORE_PASSWORD                | :red_circle:   | Delta Dore account password                                                                                                                                                                                                |                            |
-| TYDOM_PASSWORD                    | :red_circle:   | Tydom password                                                                                                                                                                                                             |                            |
-| TYDOM_IP                          | :white_circle: | Tydom IPv4 address or FQDN                                                                                                                                                                                                 | `mediation.tydom.com`      |
+| DELTADORE_LOGIN                   | :white_circle: | Delta Dore account login                                                                                                                                                                                                   |                            |
+| DELTADORE_PASSWORD                | :white_circle: | Delta Dore account password                                                                                                                                                                                                |                            |
+| TYDOM_PASSWORD                    | :white_circle: | Tydom password. Not needed for a local connection, see above                                                                                                                                                              |                            |
+| TYDOM_IP                          | :white_circle: | Tydom IPv4 address or FQDN. Set it to connect locally and pair with the hub's button                                                                                                                                       | `mediation.tydom.com`      |
+| TYDOM_STATE_DIR                   | :white_circle: | Where the local password obtained by pairing is stored. Must be persistent, otherwise the button is needed on every start                                                                                                   | `/data`                    |
+| TYDOM_PAIRING_TIMEOUT             | :white_circle: | How long to wait for the hub's button at startup, in seconds                                                                                                                                                               | `180`                      |
 | TYDOM_POLLING_INTERVAL            | :white_circle: | Tydom polling interval (in second) for devices need polling (like Tywatt)                                                                                                                                                  | `300`                      |   
 | TYDOM_ALARM_PIN                   | :white_circle: | Tydom Alarm PIN                                                                                                                                                                                                            | `None`                     |
 | TYDOM_ALARM_HOME_ZONE             | :white_circle: | Tydom alarm home zone                                                                                                                                                                                                      | `1`                        |
@@ -27,6 +34,8 @@ Please note that only one of DELTADORE_LOGIN + DELTADORE_PASSWORD or TYDOM_PASSW
 | THERMOSTAT_HEAT_MODE_TEMP_DEFAULT | :white_circle: | Default temperature when switching to heating mode                                                                                                                                                                         | `16`                       |                                                                                                                                                                            
 
 ## Complete example
+
+Using a Tydom password (works locally or through the Delta Dore relay):
 
 <!-- tabs:start -->
 #### **Docker Compose**
@@ -48,6 +57,35 @@ docker run -d --name tydom2mqtt \
   -e TYDOM_MAC="001A25XXXXXX" \
   -e TYDOM_PASSWORD="azerty123456789" \
   -e TYDOM_IP="192.168.1.33" \  
+  ghcr.io/tydom2mqtt/tydom2mqtt
+```
+<!-- tabs:end -->
+
+Or, for a local connection, pairing with the hub's button instead (a
+persistent volume on `/data` is required, otherwise the button is needed on
+every start):
+
+<!-- tabs:start -->
+#### **Docker Compose**
+```yaml
+version: '3'
+
+services:
+  tydom2mqtt:
+    image: ghcr.io/tydom2mqtt/tydom2mqtt
+    container_name: tydom2mqtt
+    environment:
+      - TYDOM_MAC=001A25XXXXXX
+      - TYDOM_IP=192.168.1.33
+    volumes:
+      - ./tydom-data:/data
+```
+#### **Docker**
+```bash
+docker run -d --name tydom2mqtt \
+  -e TYDOM_MAC="001A25XXXXXX" \
+  -e TYDOM_IP="192.168.1.33" \
+  -v "$(pwd)/tydom-data:/data" \
   ghcr.io/tydom2mqtt/tydom2mqtt
 ```
 <!-- tabs:end -->

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -34,6 +34,10 @@ docker run -d --name tydom2mqtt \
 ```
 <!-- tabs:end -->
 
+?> Connecting to a hub on your local network? You don't need `TYDOM_PASSWORD`
+at all: leave it out and press the button on the hub when asked, see
+[the configuration options](/configuration/) for details.
+
 ?> [Please find here all the configuration options.](/configuration/)
 
 !> Are you a Home-Assistant user? \

--- a/docs/introduction/README.md
+++ b/docs/introduction/README.md
@@ -21,15 +21,16 @@ services:
     container_name: tydom2mqtt
     environment:
       - TYDOM_MAC=001A25XXXXXX
-      - TYDOM_PASSWORD=azerty123456789
       - TYDOM_IP=192.168.1.33
+    volumes:
+      - ./tydom-data:/data
 ```
 #### **Docker**
 ```bash
 docker run -d --name tydom2mqtt \
   -e TYDOM_MAC="001A25XXXXXX" \
-  -e TYDOM_PASSWORD="azerty123456789" \
-  -e TYDOM_IP="192.168.1.33" \  
+  -e TYDOM_IP="192.168.1.33" \
+  -v "$(pwd)/tydom-data:/data" \
   ghcr.io/tydom2mqtt/tydom2mqtt
 ```
 <!-- tabs:end -->


### PR DESCRIPTION
Builds on #312 , base branch set to its head.

That PR made `tydom2mqtt` fetch and store the hub's local password on its
own — press the button once, nothing to configure by hand from then on.
`TYDOM_PASSWORD` no longer serves any purpose in local mode once that's in
place, and only remains as a way to misconfigure it: the value most people
have at hand is the Delta Dore cloud password, which a local hub always
rejects.

This is entirely optional and breaking, offered separately for you to decide:

- Local mode needs only `TYDOM_IP`. Upgrading needs one button press, and a
  persistent volume on `/data` for installs that aren't Home Assistant
  add-ons.
- Remote mode (no `TYDOM_IP`) now requires `DELTADORE_LOGIN` and
  `DELTADORE_PASSWORD`, since there's no button to press on a cloud relay.

Docs and examples updated accordingly. Versioning/changelog left to you.

## Testing

Same as the base PR — `pytest` passes, `ruff format` clean, verified live
against a real hub with the password removed from the environment entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)